### PR TITLE
Add support for running multiple servers

### DIFF
--- a/src/main/java/net/zoldar/ldap/testserver/Server.java
+++ b/src/main/java/net/zoldar/ldap/testserver/Server.java
@@ -21,12 +21,58 @@ public class Server {
         servers = new HashMap<Integer, LdapServerResource>();
     }
 
+    public int create(LdapConfiguration config) throws Exception {
+        LdapServerResource new_server;
+        int port;
+
+        port = config.port();
+
+        if (servers.containsKey(port)) {
+            if (servers.get(port).isStarted()) {
+                throw new IllegalStateException("LDAP server already running on port " + port);
+            }
+        }
+
+        new_server = new LdapServerResourceCreator(config).getResource();
+        servers.put(port, new_server);
+        return port;
+    }
+
+    public void destroy(int serverId) {
+        if (servers.containsKey(serverId)) {
+            servers.get(serverId).stop();
+        }
+
+        servers.remove(serverId);
+    }
+
+    public void start() throws Exception {
+        for (Integer key : servers.keySet()) {
+            if (!servers.get(key).isStarted()) {
+                servers.get(key).start();
+            }
+        }
+    }
+
+    public void start(int serverId) throws Exception {
+        if (!servers.get(serverId).isStarted()) {
+            servers.get(serverId).start();
+        }
+    }
+
     public void stop() {
         for (Integer key : servers.keySet()) {
             servers.get(key).stop();
         }
     }
 
+    public void stop(int serverId) {
+        if (servers.containsKey(serverId)) {
+            servers.get(serverId).stop();
+        }
+    }
+
+    /* functions provided for backwards compatability */
     public void start(LdapConfiguration config) throws Exception {
         LdapServerResource new_server;
         new_server = new LdapServerResourceCreator(config).getResource();


### PR DESCRIPTION
New functions added to create and destroy LDAP server instances so that multiple LDAP servers can be run at the same time. These servers can be started/stopped as a whole or managed individually by using their port number as a reference.

These changes should still maintain backwards compatibility, though the port() method will return a not so useful value if multiple servers have been create()ed.
