### PR TITLE
Allow passing a gateway server port

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/net/zoldar/ldap/testserver/Server.java
+++ b/src/main/java/net/zoldar/ldap/testserver/Server.java
@@ -1,5 +1,6 @@
 package net.zoldar.ldap.testserver;
 
+import org.apache.commons.cli.*;
 import com.github.trevershick.test.ldap.LdapServerResource;
 import com.github.trevershick.test.ldap.annotations.LdapConfiguration;
 import py4j.GatewayServer;
@@ -13,7 +14,32 @@ public class Server {
     private Map<Integer, LdapServerResource> servers = new HashMap<Integer, LdapServerResource>();
 
     public static void main(String[] args) throws Exception {
-        gateway = new GatewayServer(new Server());
+
+        Options options = new Options();
+
+        Option port = new Option("p", "port", true, "GatewayServer port");
+        options.addOption(port);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        CommandLine cmd;
+
+        try {
+            cmd = parser.parse(options, args);
+        } catch (ParseException e) {
+            System.out.println(e.getMessage());
+            formatter.printHelp("ldap-test-server", options);
+
+            System.exit(1);
+            return;
+        }
+
+        int gatewayPort = GatewayServer.DEFAULT_PORT;
+        if (cmd.hasOption("port")) {
+          String gatewayPortStr = cmd.getOptionValue("port");
+          gatewayPort = Integer.parseInt(gatewayPortStr);
+        }
+        gateway = new GatewayServer(new Server(), gatewayPort);
         gateway.start();
         System.out.println("Gateway server started on port "+gateway.getPort()+"!");
     }


### PR DESCRIPTION
I found the need for this because of our CI process where we run several builds at the same time and each needs its own ldap-test-server(and respective gateway)
